### PR TITLE
Fix minor typos in latecomers guide to crypto annotations

### DIFF
--- a/src/pug/pages/annotations/latecomers-guide-to-crypto.pug
+++ b/src/pug/pages/annotations/latecomers-guide-to-crypto.pug
@@ -210,7 +210,7 @@ block body
             | Because it's all a scam wrapped in technical and financial obscurantism. And the best case in point is probably this article which borders more on apologetics than journalism.
           .annotation 
             .commenter Grady Booch 
-            | On the other hand, I observed that my strongest-held belief about crypto, though, is that it not that it is terribly explained, but rather, it is altogether terrible.
+            | On the other hand, I observed that my strongest-held belief about crypto, though, is not that it is terribly explained, but rather, it is altogether terrible.
   
   .group 
     .left 

--- a/src/pug/pages/annotations/latecomers-guide-to-crypto.pug
+++ b/src/pug/pages/annotations/latecomers-guide-to-crypto.pug
@@ -116,7 +116,7 @@ block body
       .content
         .annotation(role="comment" data-annotation-id="1" id="matt-damon-larry-david")
           .commenter Molly White
-          | Crypto skeptic Ben McKenzie has argued that this is a sign that the bubble has become precariously large, not that crypto has become ubiquitous: "The celebrities are a symptom of a much bigger problem... You've got all this money and you're trying to get it out to more people and get more people to buy. And if one were to compare cryptocurrency to, say, an MLM or a ponzi, then you would need ever more people to come in to keep the thing going. Celebrities are sort of the natural endpoint for that. At its biggest, you need the biggest: you need Matt Damon and Larry David and sports stars to sell it." (<a href="https://youtu.be/AijwGyNLtjc?t=865"><i>Crypto Critics' Corner</i>, episode 51</a>)
+          | Crypto skeptic Ben McKenzie has argued that this is a sign that the bubble has become precariously large, not that crypto has become ubiquitous: "The celebrities are a symptom of a much bigger problem… You've got all this money and you're trying to get it out to more people and get more people to buy. And if one were to compare cryptocurrency to, say, an MLM or a ponzi, then you would need ever more people to come in to keep the thing going. Celebrities are sort of the natural endpoint for that. At its biggest, you need the biggest: you need Matt Damon and Larry David and sports stars to sell it." (<a href="https://youtu.be/AijwGyNLtjc?t=865"><i>Crypto Critics' Corner</i>, episode 51</a>)
         .annotation(role="comment" data-annotation-id="2" id="miamicoin")
           | Miami's mayor also introduced "MiamiCoin" to his city. The Miami residents and everyone else who still hold the coin <a href="https://protos.com/miamicoin-crypto-mayor-francis-suarez-bitcoin-bait-switch/">have all lost money</a>, and the coin is trading well below its initial price.
         .annotation-group(role="comment" data-annotation-id="3" id="brand-nfts") 
@@ -162,7 +162,7 @@ block body
       .content 
         .annotation(role="comment" id="rooses-views")
           p This is a statement desperately in need of some links. Although Roose has linked to his own writing quite liberally throughout this article, it certainly doesn't show "extreme skepticism", nor for that matter does his optimism seem particularly cautious. This article notably doesn't seem to link to his <a href="https://www.nytimes.com/2021/08/12/technology/penguin-nft-club.html">August 2021 <i>Times</i> article about the "Pudgy Penguins" NFT project</a>, which served to lend the project legitimacy and pump the price before the group later attempted to scam a prospective buyer of the company. No follow-up was ever published—this is a recurring theme for the articles Roose writes about various crypto projects, as you will see throughout this commentary.
-          p Roose has <a href="https://web.archive.org/web/20220219172535/https://twitter.com/kevinroose/status/1495085866192027655">publicly advocated</a> for journalists who write about crypto to be able to buy and sell cryptocurrencies and NFTs, despite himself acknowledging the "strong biasing effect" it would have and that the traditional finance equivalent of this behavior is prohibited by most reputable publications. He holds the <code>cryptoroose.eth</code> <a href="https://decrypt.co/resources/ethereum-name-service-ens-explained-guide-learn">ENS domain</a> (which he <a href="https://etherscan.io/tx/0xdd58208d954f61ed181899d4380266246eb483c8e0cb6bf2d471cc4fb64708e1">bought</a> in October for $21... plus another $136 in transaction fees). He uses the associated wallet for transactions relating to his reporting, including the $500,000 sale of an NFT representing a <i>Times</i> article that he mentions in this piece, the receipt of some Pudgy Penguins NFTs from the creator of the project (later returned), and similar.
+          p Roose has <a href="https://web.archive.org/web/20220219172535/https://twitter.com/kevinroose/status/1495085866192027655">publicly advocated</a> for journalists who write about crypto to be able to buy and sell cryptocurrencies and NFTs, despite himself acknowledging the "strong biasing effect" it would have and that the traditional finance equivalent of this behavior is prohibited by most reputable publications. He holds the <code>cryptoroose.eth</code> <a href="https://decrypt.co/resources/ethereum-name-service-ens-explained-guide-learn">ENS domain</a> (which he <a href="https://etherscan.io/tx/0xdd58208d954f61ed181899d4380266246eb483c8e0cb6bf2d471cc4fb64708e1">bought</a> in October for $21… plus another $136 in transaction fees). He uses the associated wallet for transactions relating to his reporting, including the $500,000 sale of an NFT representing a <i>Times</i> article that he mentions in this piece, the receipt of some Pudgy Penguins NFTs from the creator of the project (later returned), and similar.
    
   .group 
     .left
@@ -190,7 +190,7 @@ block body
         .annotation-group(role="comment" data-annotation-id="2" id="money-energy-talent")
           .annotation
             .commenter Anonymous 3
-            | There are so many bubbles in tech that amount to nothing ... Can pay attention to them but mostly it's just noise.
+            | There are so many bubbles in tech that amount to nothing … Can pay attention to them but mostly it's just noise.
           .annotation
             .commenter Ed Zitron 
             | Absolutely agree with this point—however he is conflating "keeping an eye on something" with "keeping an open mind about something," and "keeping an open mind about something" with "giving something the benefit of the doubt."
@@ -296,7 +296,7 @@ block body
             p The wealth could be interesting, but this is also something that is easily questioned.
           .annotation.thread-2
             .commenter Molly White
-            | Technolibertarianism has been around longer than crypto, though—why are we now taking it on faith that it will be a "transformative force... in the coming years"?
+            | Technolibertarianism has been around longer than crypto, though—why are we now taking it on faith that it will be a "transformative force… in the coming years"?
           .annotation
             .commenter Anonymous 3
             | This is where Roose goes from being objective to prescriptive. With no justification. Just that crypto is "inevitable" for no reason.
@@ -323,7 +323,7 @@ block body
         .annotation-group(role="comment" data-annotation-id="2" id="the-half-of-it")
           .annotation 
             .commenter Anonymous 3 
-            | The other "half of it" is that it's a zero-sum game so for every dogecoin millionaire there's hundreds of people who lost everything. All to produce ... nothing ... just a giant financial redistribution game with no economic output.
+            | The other "half of it" is that it's a zero-sum game so for every dogecoin millionaire there's hundreds of people who lost everything. All to produce … nothing … just a giant financial redistribution game with no economic output.
         .annotation-group(role="comment" data-annotation-id="3" id="oil-discovery")
           .annotation 
             .commenter Molly White 
@@ -508,7 +508,7 @@ block body
             | This is a bit like the claim that everyone hated the internet in 1993.
           .annotation.thread-2
             .commenter Anonymous 4 
-            | The skepticism that I remember from 2009 was largely focused on the fact that Facebook didn't seem to have a viable path to profitability based off straight ad sales... which was true. They had to become a vast data harvesting machine rather than a mere social media platform. Ditto for Twitter.
+            | The skepticism that I remember from 2009 was largely focused on the fact that Facebook didn't seem to have a viable path to profitability based off straight ad sales… which was true. They had to become a vast data harvesting machine rather than a mere social media platform. Ditto for Twitter.
         .annotation-group(role="comment" data-annotation-id="2" id="pundits-predicted")
           .annotation
             .commenter Ed Zitron 
@@ -590,7 +590,7 @@ block body
             | This is incredibly hand wavy and meaningless — which veterans and veterans of what? In fact, what's striking is the huge number of veterans of the dot-com and the actual computer science field who have been outspoken critics of crypto. But here, all that is related are the supposed views of some amorphous, undefined set of "tech veterans" in order to lend credibility to this idea that this crypto has staying power.
           .annotation 
             .commenter Molly White 
-            | Vague appeal to authority... No mention of the tech veterans (David S. H. Rosenthal, Grady Booch, Nicholas Weaver, James Mickens, many others) who are deeply skeptical.
+            | Vague appeal to authority… No mention of the tech veterans (David S. H. Rosenthal, Grady Booch, Nicholas Weaver, James Mickens, many others) who are deeply skeptical.
           .annotation 
             .commenter Ed Zitron 
             | "Many tech veterans I've spoken to"?  This would get me a call from an editor. The call would ask me who they were, and why their arguments were so bland that I could not quote at least one of them in my piece. 
@@ -626,10 +626,10 @@ block body
         .annotation-group(role="comment" data-annotation-id="2" id="bottomless-well")
           .annotation
             .commenter Molly White 
-            | Such as...? This is reminiscent of the many discussions with crypto proponents who handwave that there are all these amazing projects doing incredible work that all the skeptics are clearly ignoring, and then refuse to name even one.
+            | Such as…? This is reminiscent of the many discussions with crypto proponents who handwave that there are all these amazing projects doing incredible work that all the skeptics are clearly ignoring, and then refuse to name even one.
           .annotation.thread
             .commenter Dirty Bubble Media
-            | Yeah, I notice there isn't a single concrete, positive example in this entire article...
+            | Yeah, I notice there isn't a single concrete, positive example in this entire article…
         .annotation(role="comment" data-annotation-id="3" id="footholds")
           .commenter Ed Zitron 
           | Excuse me, <i>what</i>? Where are the footholds? Where do they lead? Where are the easy footholds for people to get involved that don't involve buying something? What are they? Where are they? This is not close to true!
@@ -657,7 +657,7 @@ block body
       .content
         .annotation(role="comment" data-annotation-id="1" id="surveys-have-suggested")
           .commenter Molly White
-          | Roose is again citing questionable surveys to make broad claims... I don't doubt his conclusion in this particular case, but he really needs to work with better data. The poll in question is from the Gemini crypto exchange and featured a "total sample of 3,000 U.S. adults, ages 18 to 65 with $40,000 or more in household income. Survey respondents were polled from October 19-November 16, 2020, and included 921 self-identifying current cryptocurrency owners and 1,697 consumers who were interested in learning more about cryptocurrency." The <i>Cheddar News</i> article he's linking here tries to claim that it also suggests crypto is somehow becoming more diverse, which is the more eyebrow-raising claim, but at least not one that Roose has chosen to make.
+          | Roose is again citing questionable surveys to make broad claims… I don't doubt his conclusion in this particular case, but he really needs to work with better data. The poll in question is from the Gemini crypto exchange and featured a "total sample of 3,000 U.S. adults, ages 18 to 65 with $40,000 or more in household income. Survey respondents were polled from October 19-November 16, 2020, and included 921 self-identifying current cryptocurrency owners and 1,697 consumers who were interested in learning more about cryptocurrency." The <i>Cheddar News</i> article he's linking here tries to claim that it also suggests crypto is somehow becoming more diverse, which is the more eyebrow-raising claim, but at least not one that Roose has chosen to make.
         .annotation-group(role="comment" data-annotation-id="2" id="left-wing-ethereum")
           .annotation 
             .commenter Molly White
@@ -809,7 +809,7 @@ block body
             | This is not some axiom of reality, there's no universal power enforcing this, this is just uncritically repeating the crypto sales pitch.
         .annotation-group(role="comment" id="break-into-many-computers" data-annotation-id="5")
           .annotation
-            | Is he arguing the only way to attack a blockchain is to... compromise a bunch of miners that other people control??
+            | Is he arguing the only way to attack a blockchain is to… compromise a bunch of miners that other people control??
   
   .group
     .left 
@@ -818,7 +818,7 @@ block body
     .right 
       .content 
         .annotation(role="comment" id="unlike-spreadsheet") 
-          | This analogy is really falling apart... you could publish a Google spreadsheet to make it publicly visible too, and whether the blockchain itself is open-source or not is a separate topic to whether it's a public or private blockchain (there are open-source private blockchains). We also seem to be working up to the suggestion that blockchains are the only reasonable way to verify that data hasn't changed, which is far from accurate.
+          | This analogy is really falling apart… you could publish a Google spreadsheet to make it publicly visible too, and whether the blockchain itself is open-source or not is a separate topic to whether it's a public or private blockchain (there are open-source private blockchains). We also seem to be working up to the suggestion that blockchains are the only reasonable way to verify that data hasn't changed, which is far from accurate.
   
   .group
     .left 
@@ -1124,7 +1124,7 @@ block body
             | "We all know this is a pyramid scheme, therefore it is not a pyramid scheme."
           .annotation 
             .commenter Molly White
-            | Perhaps they claim to be fully informed, but I have not found them to spend a whole lot of time informing the folks they're so "fond of" recruiting on the risks...
+            | Perhaps they claim to be fully informed, but I have not found them to spend a whole lot of time informing the folks they're so "fond of" recruiting on the risks…
           .annotation
             .commenter Dr. Catherine Flick 
             | Plenty of investors go in with eyes wide open to lots of scams. Doesn't make them not scams.
@@ -1138,7 +1138,7 @@ block body
         .annotation-group(role="comment" id="inherently-valuable" data-annotation-id="1")
           .annotation
             .commenter Dirty Bubble Media 
-            | Technology is valuable insofar as it is useful... no such thing as an "inherently valuable" technology.
+            | Technology is valuable insofar as it is useful… no such thing as an "inherently valuable" technology.
           .annotation 
             .commenter Dr. Catherine Flick
             | Inherently valuable but apparently also neutral at the same time. Lovely square to circle there.
@@ -1252,7 +1252,7 @@ block body
             | Again, it's not early. Also, while he's quick to portray parallels <i>for</i> crypto by drawing on previous phenomena like social media or "the Internet," when it comes to the case <i>against</i> crypto, why doesn't he bring up credit default swaps, mortgage backed securities and the catastrophe of 2008?
           .annotation.thread
             .commenter Molly White
-            | He sure does say "it's still early" a lot for an article entitled "The Latecomer's Guide to Crypto"... 
+            | He sure does say "it's still early" a lot for an article entitled "The Latecomer's Guide to Crypto"… 
 
   .group 
     .left 
@@ -1446,7 +1446,7 @@ block body
             | Because it's true.
           .annotation 
             .commenter Anonymous 1
-            | OK, yes, so we might destroy the planet and have no ice caps when this is over, but hear me out...
+            | OK, yes, so we might destroy the planet and have no ice caps when this is over, but hear me out…
           .annotation 
             .commenter Ed Zitron
             p I am going to be empathetic with Kevin here: he is likely writing this as objectively as he can (and veering into both-sidesism) because he knows that if he <i>doesn't</i> write it like this, he will be obliterated in the comments, or on Twitter.
@@ -1516,7 +1516,7 @@ block body
             | Yes, the people making this argument really <a href="https://twitter.com/molly0xFFF/status/1500613593053675522">like to compare the total overall energy usage of traditional finance to the total overall energy usage of their blockchain of choice</a>, conveniently ignoring the massive difference in the number of transactions processed by each. Traditional banking absolutely uses a lot of energy, but total energy usage is not a good comparison.
           .annotation 
             .commenter Anonymous 3 
-            | Traditional banking also has thousands of products it offers to billions of people. Crypto is one facet of a financial system payments ... which it sucks at. Crypto isn't writing mortgages or doing investment banking. So it's really an apples and oranges comparison.
+            | Traditional banking also has thousands of products it offers to billions of people. Crypto is one facet of a financial system payments … which it sucks at. Crypto isn't writing mortgages or doing investment banking. So it's really an apples and oranges comparison.
           .annotation
             .commenter Ed Zitron
             | I feel as if it's irresponsible to not include how much energy our existing financial system uses. I realize this is probably difficult to calculate, which is why I'd have it done for this article! It'd be interesting to make a real comparison. Just saying this without a definition of what "a lot of energy" means allows someone to confirm their bias in whatever direction they want to!
@@ -1591,7 +1591,7 @@ block body
         .annotation-group(role="comment" id="bitcoin-energy-needs")
           .annotation
             .commenter Molly White 
-            | Or... ever. Because it's literally designed this way. The entire design of the system is predicated on it becoming harder and harder to do the computation required to mine new Bitcoins, thus requiring more and more energy expenditure over time.
+            | Or… ever. Because it's literally designed this way. The entire design of the system is predicated on it becoming harder and harder to do the computation required to mine new Bitcoins, thus requiring more and more energy expenditure over time.
           .annotation.thread
             .commenter Dr. Catherine Flick
             | Yeah, this is so disingenuous.
@@ -1783,10 +1783,10 @@ block body
         .annotation-group(role="comment" id="really-believe" data-annotation-id="2")
           .annotation
             .commenter Dirty Bubble Media
-            | One would expect the opposite attitude from rational investors...
+            | One would expect the opposite attitude from rational investors…
         .annotation-group(role="comment" id="cult" data-annotation-id="3")
           .annotation
-            | So... like a cult?
+            | So… like a cult?
   .group 
     .left 
       .content 
@@ -1824,7 +1824,7 @@ block body
       li <a href="https://twitter.com/neilturkewitz"><b>Neil Turkewitz</b></a> – a consultant and copyright activist, who is President at Turkewitz Consulting Group and a member of the Artist Rights Alliance. He was previously an executive at the Recording Industry Association of America (RIAA) and served on the Board of the Chamber of Commerce's Global Intellectual Property Center. More of his writing can be found on <a href="https://medium.com/@nturkewitz_56674">Medium</a>.
       li <a href="https://twitter.com/molly0xFFF"><b>Molly White</b></a> – a software engineer and the creator of <a href="http://web3isgoinggreat.com/"><i>Web3 Is Going Just Great</i></a>, who has also written some <a href="https://blog.mollywhite.net/blockchain/">essays</a> about crypto-related topics
       li <a href="https://twitter.com/edzitron"><b>Ed Zitron</b></a> – an author, journalist, and media relations company CEO, who also writes on <a href="https://ez.substack.com/">Substack</a>
-      li ...and several contributors who would prefer to remain anonymous.
+      li …and several contributors who would prefer to remain anonymous.
     p Three of the contributors have also published their longer-form thoughts on this <i>New York Times</i> article: <a href="https://ez.substack.com/p/the-emperors-new-blockchain">Ed Zitron</a>, <a href="https://medium.com/@nturkewitz_56674/the-latecomers-guide-to-crypto-a-few-thoughts-6f5d7b87b0b2">Neil Turkewitz</a>, and <a href="https://medium.com/@Stephen.Diehl/the-new-york-times-has-a-crypto-blindspot-d5de2a889665">Stephen Diehl</a>.
   
     .fine-print


### PR DESCRIPTION
Thanks for the great article! Just fixed a typo (double "that it") I caught while reading (double "that it"), and replaced `...` with a real ellipsis (`…`).

Haven't finished the full article yet and might push more fixes, should there be anything. Feel free to already merge though.