### PR TITLE
Add subheaders so its clear to first time readers that the source is on the left and annotations are on the right:

### DIFF
--- a/src/pug/pages/annotations/sbf-ftx-pre-mortem-overview.pug
+++ b/src/pug/pages/annotations/sbf-ftx-pre-mortem-overview.pug
@@ -57,6 +57,11 @@ block body
     p Sam Bankman-Fried has apparently decided to fill his time spent confined to his parents' Palo Alto home with blogging, perhaps in the hopes that he can just blog his way out of the <a href="https://newsletter.mollywhite.net/p/issue-13-dont-threaten-me-with-a" target="_blank">massive criminal and civil penalties</a> he's facing.
     p Although many of his statements here repeat things he's said elsewhere, I think it is useful to be able to analyze some of the story he's trying to spin all in one place, rather than cobbling his narrative together from multiple sources.
     p It's remarkable the extent to which SBF outright lies, or at the very least twists his version of events to distort reality in his favor. I don't intend to annotate further posts from him—which I suspect will be many—but instead hope that this will be sufficient to give some idea of just how thoroughly misleading his statements are.
+  .group
+   .left
+     h2(style={'text-align': 'center', 'width': '100%'}) Source
+   .right(style={'background-color': 'transparent'})
+     h2(style={'text-align': 'center', 'width': '100%'}) Annotations
   .group.first
     .left
       .content


### PR DESCRIPTION
Just a suggestion.

Before:
<img width="1395" alt="Screen Shot 2023-01-25 at 2 51 00 PM" src="https://user-images.githubusercontent.com/74692/214709677-0649d08e-3556-45f4-9a9d-09908eb49de5.png">


After:
<img width="1378" alt="Screen Shot 2023-01-25 at 2 48 02 PM" src="https://user-images.githubusercontent.com/74692/214709735-b5c2968e-535f-491d-b739-1759b56b02c2.png">

